### PR TITLE
拆分代碼庫的 shell 腳本

### DIFF
--- a/split-packages.sh
+++ b/split-packages.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+packages=(
+    arabic
+    burmese
+    devanagari
+    greek
+    hebrew
+    jap-poly
+    kyril-international
+    latin-international
+    manju
+    mongol
+    qyeyshanglr-hanja
+    tangut-poly4
+    thai-stupid
+    tibetan
+    middle-chinese
+    uyghur
+)
+
+filename_mapping='
+s/_/-/g;
+s/^triungkoxsampheng.*$/middle-chinese/;
+s/^zyenpheng.*$/middle-chinese/;
+s/^中古三拼方案.*$/middle-chinese/;
+s/^阿拉伯字母編碼.*$/arabic/
+'
+
+packages_dir='packages'
+
+get_package() {
+    local file=$(echo "$1" | sed "${filename_mapping}")
+    local package
+    for package in ${packages[@]}; do
+        if [[ $file =~ ^$package ]]; then
+            echo $package
+        fi
+    done
+}
+
+cd $(dirname "$0")
+for file in *; do
+    package=$(get_package "${file}")
+    if [[ -z "${package}" ]]; then
+        echo "Skipped ${file}"
+        continue
+    fi
+    target_dir="${packages_dir}/rime-${package}"
+    mkdir -p "${target_dir}"
+    cp "${file}" "${target_dir}"
+done
+
+self_account=lotem
+upstream_account=biopolyhedron
+
+for package_dir in "${packages_dir}"/*; do
+    pushd "${package_dir}"
+    git init && git add . && git commit -m 'initial upload'
+    repo_url="https://github.com/${upstream_account}/$(basename "${package_dir}").git"
+    echo "Uploading to new repository ${repo_url}"
+    git remote add origin "${repo_url/${upstream_account}/${self_account}}"
+    git remote add upstream "${repo_url}"
+    git push -u origin master
+    popd
+done


### PR DESCRIPTION
哇，我晚了一步。

這個腳本完成 https://github.com/biopolyhedron/rime_schemata/issues/2#issuecomment-262967954 「拆分軟件包操作步驟」中的第 6. 步「往新代碼庫上傳文件」。

用腳本自動拆分並上傳，前提是嚴博已經通過 GitHub 網站在 [自己賬號]() 下建立了一組空的代碼庫，用來發佈各個軟件包。代碼庫名稱暫定爲 `split-packages.sh` 腳本開頭定義的 `packages` 中的包名、各自再加上 `rime-` 前綴。
原來叫做 `xxx_yy.schema.yaml`、`xxx_yy.dict.yaml` 的文件，都劃入新的 `xxx-yy` 軟件包，其代碼庫爲 <https://github.com/biopolyhedron/rime-xxx-yy> 。個別文件名和包名不一致的，我在 `filename_mapping` 裏面追加了對應關係。
軟件包的劃分和命名，請嚴博過目，如有不妥之處再做必要修改。最後執行這個，就把剩下的工作全做完了。（再補上個 README）
